### PR TITLE
refactor: align devcontainer image registry names and fix badge links

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Ubuntu + Bun + Docker",
-  "image": "ghcr.io/iamvikshan/devcontainers/ai:latest",
+  "image": "ghcr.io/iamvikshan/devcontainer/agents:latest",
 
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {

--- a/.github/actions/notes/action.yml
+++ b/.github/actions/notes/action.yml
@@ -43,7 +43,7 @@ runs:
             SIZE_VAL=$(cat "$size_file")
             
             # Add row to release notes with versioned tag links
-            echo "| $IMG_NAME | $NEW_TAG | $(date +'%Y-%m-%d') | [GHCR](https://ghcr.io/$REPO/$IMG_NAME:$NEW_TAG) · [Docker Hub](https://hub.docker.com/r/vikshan/$IMG_NAME:$NEW_TAG) |" >> release_notes.md
+            echo "| $IMG_NAME | $NEW_TAG | $(date +'%Y-%m-%d') | [GHCR](https://ghcr.io/$OWNER/devcontainer/$IMG_NAME:$NEW_TAG) · [Docker Hub](https://hub.docker.com/r/vikshan/$IMG_NAME:$NEW_TAG) |" >> release_notes.md
             
             # Smart replace the size in the README table inline
             sed -i -E "s/\|[[:space:]]*\*\*$IMG_NAME\*\*[[:space:]]*\|[[:space:]]*[^|]+[[:space:]]*\|/\| **$IMG_NAME** \| $SIZE_VAL \|/" README.md

--- a/.github/actions/notes/update_docs.py
+++ b/.github/actions/notes/update_docs.py
@@ -127,7 +127,7 @@ def update_docs():
                 content = re.sub(r"Smallest size - Only [0-9]+ MB!", f"Smallest size - Only {size}!", content)
             elif name == 'ubuntu-bun-node':
                 content = re.sub(r"Balanced size - Feature-rich at only [0-9]+ MB", f"Balanced size - Feature-rich at only {size}", content)
-            elif name == 'ai':
+            elif name == 'agents':
                 content = re.sub(r"AI additions - Custom taste workspace at only [0-9]+ MB", f"AI additions - Custom taste workspace at only {size}", content)
 
         with open('docs/IMAGE_VARIANTS.md', 'w') as fh:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -78,7 +78,7 @@ jobs:
             bun_node: "images/bun-node/**"
             ubuntu_bun: "images/ubuntu-bun/**"
             ubuntu_bun_node: "images/ubuntu-bun-node/**"
-            ubuntu_bun_ai: "images/agents/**"
+            agents: "images/agents/**"
 
       - name: Construct DAG Matrices
         id: matrix
@@ -110,7 +110,7 @@ jobs:
               DERIVATIVES+=("ubuntu-bun-node")
             fi
             
-            if [ "${{ steps.filter.outputs.ubuntu_tools }}" == "true" ] || [ "${{ steps.filter.outputs.ubuntu_bun }}" == "true" ] || [ "${{ steps.filter.outputs.ubuntu_bun_ai }}" == "true" ]; then
+            if [ "${{ steps.filter.outputs.ubuntu_tools }}" == "true" ] || [ "${{ steps.filter.outputs.ubuntu_bun_node }}" == "true" ] || [ "${{ steps.filter.outputs.agents }}" == "true" ]; then
               AI_CHANGED="true"
             else
               AI_CHANGED="false"

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   GL_USERNAME: vikshan
-  GHCR_BASE: ghcr.io/${{ github.repository }}
+  GHCR_BASE: ghcr.io/iamvikshan/devcontainer
 
 jobs:
   # ============================================
@@ -78,7 +78,7 @@ jobs:
             bun_node: "images/bun-node/**"
             ubuntu_bun: "images/ubuntu-bun/**"
             ubuntu_bun_node: "images/ubuntu-bun-node/**"
-            ubuntu_bun_ai: "images/ai/**"
+            ubuntu_bun_ai: "images/agents/**"
 
       - name: Construct DAG Matrices
         id: matrix
@@ -174,7 +174,7 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_BASE }}/${{ matrix.image }}
-            registry.gitlab.com/${{ env.GL_USERNAME }}/devcontainers/${{ matrix.image }}
+            registry.gitlab.com/${{ env.GL_USERNAME }}/devcontainers/devcontainer/${{ matrix.image }}
             ${{ env.GL_USERNAME }}/${{ matrix.image }}
           tags: |
             type=raw,value=${{ needs.prepare.outputs.new_tag }}
@@ -266,7 +266,7 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_BASE }}/${{ matrix.image }}
-            registry.gitlab.com/${{ env.GL_USERNAME }}/devcontainers/${{ matrix.image }}
+            registry.gitlab.com/${{ env.GL_USERNAME }}/devcontainers/devcontainer/${{ matrix.image }}
             ${{ env.GL_USERNAME }}/${{ matrix.image }}
           tags: |
             type=raw,value=${{ needs.prepare.outputs.new_tag }}
@@ -307,8 +307,8 @@ jobs:
   # ============================================
   # Job 3.5: Build AI/Taste Custom Image
   # ============================================
-  build-ai:
-    name: AI -> ai
+  build-agents:
+    name: AI -> agents
     needs: [prepare, build-derivatives]
     if: |
       always() &&
@@ -348,9 +348,9 @@ jobs:
         uses: docker/metadata-action@v6.2.0
         with:
           images: |
-            ${{ env.GHCR_BASE }}/ai
-            registry.gitlab.com/${{ env.GL_USERNAME }}/devcontainers/ai
-            ${{ env.GL_USERNAME }}/ai
+            ${{ env.GHCR_BASE }}/agents
+            registry.gitlab.com/${{ env.GL_USERNAME }}/devcontainers/devcontainer/agents
+            ${{ env.GL_USERNAME }}/agents
           tags: |
             type=raw,value=${{ needs.prepare.outputs.new_tag }}
             type=raw,value=latest
@@ -358,7 +358,7 @@ jobs:
       - name: Build and Push
         uses: docker/build-push-action@v7.3.0
         with:
-          context: images/ai
+          context: images/agents
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -373,17 +373,17 @@ jobs:
           sleep 10
 
           # 1. Extract Size from remote manifest
-          skopeo inspect docker://${{ env.GHCR_BASE }}/ai:${{ needs.prepare.outputs.new_tag }} | \
-          jq -r '[.LayersData[] | .Size] | add / 1048576 | floor | tostring + " MB"' > metadata/ai.size
+          skopeo inspect docker://${{ env.GHCR_BASE }}/agents:${{ needs.prepare.outputs.new_tag }} | \
+          jq -r '[.LayersData[] | .Size] | add / 1048576 | floor | tostring + " MB"' > metadata/agents.size
 
           # 2. Extract specific devcontainer.tool.* OCI Labels
-          skopeo inspect docker://${{ env.GHCR_BASE }}/ai:${{ needs.prepare.outputs.new_tag }} | \
-          jq -r '.Labels | to_entries[] | select(.key | startswith("devcontainer.tool.")) | "\(.key | sub("devcontainer\\.tool\\."; ""))=\(.value)"' > metadata/ai.versions
+          skopeo inspect docker://${{ env.GHCR_BASE }}/agents:${{ needs.prepare.outputs.new_tag }} | \
+          jq -r '.Labels | to_entries[] | select(.key | startswith("devcontainer.tool.")) | "\(.key | sub("devcontainer\\.tool\\."; ""))=\(.value)"' > metadata/agents.versions
 
       - name: Upload Metadata
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: metadata-ai
+          name: metadata-agents
           path: metadata/
           retention-days: 1
 
@@ -392,14 +392,14 @@ jobs:
   # ============================================
   finalize:
     name: Finalize Release Notes
-    needs: [prepare, build-bases, build-derivatives, build-ai]
+    needs: [prepare, build-bases, build-derivatives, build-agents]
     if: |
       always() &&
       !cancelled() &&
       (needs.prepare.outputs.bases != '[]' || needs.prepare.outputs.derivatives != '[]' || needs.prepare.outputs.ai_changed == 'true') &&
       (needs.build-bases.result == 'success' || needs.build-bases.result == 'skipped') &&
       (needs.build-derivatives.result == 'success' || needs.build-derivatives.result == 'skipped') &&
-      (needs.build-ai.result == 'success' || needs.build-ai.result == 'skipped')
+      (needs.build-agents.result == 'success' || needs.build-agents.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -424,7 +424,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [bun, bun-node, ubuntu-tools, ubuntu-bun, ubuntu-bun-node, ai]
+        image: [bun, bun-node, ubuntu-tools, ubuntu-bun, ubuntu-bun-node, agents]
     steps:
       - name: Download updated README
         uses: actions/download-artifact@v8.0.1
@@ -445,7 +445,7 @@ jobs:
   # ============================================
   cleanup:
     name: Prune Untagged GHCR Images -> ${{ matrix.image }}
-    needs: [build-bases, build-derivatives, build-ai]
+    needs: [build-bases, build-derivatives, build-agents]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -453,7 +453,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [bun, bun-node, ubuntu-tools, ubuntu-bun, ubuntu-bun-node, ai]
+        image: [bun, bun-node, ubuntu-tools, ubuntu-bun, ubuntu-bun-node, agents]
     steps:
       - name: Clean GHCR
         uses: vlaurin/action-ghcr-prune@v0.6.0
@@ -461,6 +461,6 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           organization: ${{ github.repository_owner }}
-          container: devcontainers/${{ matrix.image }}
+          container: devcontainer/${{ matrix.image }}
           keep-younger-than: 7
           prune-untagged: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,19 @@ All notable changes to this project are documented below. This release contains 
 
 ### Released Environments
 
-| Container | Version | Date | Registry Links |
-|---|---|---|---|
-| bun-node | v0.1.1 | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/bun-node:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/bun-node:v0.1.1) |
-| bun | v0.1.1 | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/bun:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/bun:v0.1.1) |
-| ubuntu-bun-ai | v0.1.1 | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/ubuntu-bun-ai:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/ubuntu-bun-ai:v0.1.1) |
-| ubuntu-bun-node | v0.1.1 | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/ubuntu-bun-node:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/ubuntu-bun-node:v0.1.1) |
-| ubuntu-bun | v0.1.1 | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/ubuntu-bun:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/ubuntu-bun:v0.1.1) |
-| ubuntu-tools | v0.1.1 | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/ubuntu-tools:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/ubuntu-tools:v0.1.1) |
+| Container       | Version | Date       | Registry Links                                                                                                                                  |
+| --------------- | ------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| bun-node        | v0.1.1  | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/bun-node:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/bun-node:v0.1.1)               |
+| bun             | v0.1.1  | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/bun:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/bun:v0.1.1)                         |
+| ubuntu-bun-ai   | v0.1.1  | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/ubuntu-bun-ai:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/ubuntu-bun-ai:v0.1.1)     |
+| ubuntu-bun-node | v0.1.1  | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/ubuntu-bun-node:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/ubuntu-bun-node:v0.1.1) |
+| ubuntu-bun      | v0.1.1  | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/ubuntu-bun:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/ubuntu-bun:v0.1.1)           |
+| ubuntu-tools    | v0.1.1  | 2026-07-12 | [GHCR](https://ghcr.io/iamvikshan/devcontainers/ubuntu-tools:v0.1.1) · [Docker Hub](https://hub.docker.com/r/vikshan/ubuntu-tools:v0.1.1)       |
 
 ### Environment Tool Versions
 
 #### Ubuntu-Based Environments
+
 ```properties
 bun=1.3.14
 node=24.18.0
@@ -23,6 +24,7 @@ ubuntu=26.04
 ```
 
 #### Alpine-Based Environments
+
 ```properties
 bun=1.3.14
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ interactive shell experience.
 | **bun-node**        | 82 MB  | Alpine | ✅  | ✅             | Full-stack development    |
 | **ubuntu-bun**      | 160 MB | Ubuntu | ✅  | ❌             | Ubuntu-based Bun projects |
 | **ubuntu-bun-node** | 217 MB | Ubuntu | ✅  | ✅             | Ubuntu full-stack         |
-| **agents**          | 160 MB | Ubuntu | ✅  | ❌ (Bun proxy) | Personal AI workspace     |
+| **agents**          | 160 MB | Ubuntu | ✅  | ✅             | Personal AI workspace     |
 | **ubuntu-tools**    | 127 MB | Ubuntu | ❌  | ❌             | Tools-only automation     |
 
 ### 🎯 Choose Your Image

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ interactive shell experience.
 | **bun-node**        | 82 MB  | Alpine | ✅  | ✅             | Full-stack development    |
 | **ubuntu-bun**      | 160 MB | Ubuntu | ✅  | ❌             | Ubuntu-based Bun projects |
 | **ubuntu-bun-node** | 217 MB | Ubuntu | ✅  | ✅             | Ubuntu full-stack         |
-| **ai**              | 160 MB | Ubuntu | ✅  | ❌ (Bun proxy) | Personal AI workspace     |
+| **agents**          | 160 MB | Ubuntu | ✅  | ❌ (Bun proxy) | Personal AI workspace     |
 | **ubuntu-tools**    | 127 MB | Ubuntu | ❌  | ❌             | Tools-only automation     |
 
 ### 🎯 Choose Your Image
@@ -41,12 +41,12 @@ Need Bun runtime?
 ### 📦 Quick Start
 
 ```bash
-docker pull ghcr.io/iamvikshan/devcontainers/bun:latest
-docker pull ghcr.io/iamvikshan/devcontainers/bun-node:latest
-docker pull ghcr.io/iamvikshan/devcontainers/ubuntu-bun:latest
-docker pull ghcr.io/iamvikshan/devcontainers/ubuntu-bun-node:latest
-docker pull ghcr.io/iamvikshan/devcontainers/ai:latest
-docker pull ghcr.io/iamvikshan/devcontainers/ubuntu-tools:latest
+docker pull ghcr.io/iamvikshan/devcontainer/bun:latest
+docker pull ghcr.io/iamvikshan/devcontainer/bun-node:latest
+docker pull ghcr.io/iamvikshan/devcontainer/ubuntu-bun:latest
+docker pull ghcr.io/iamvikshan/devcontainer/ubuntu-bun-node:latest
+docker pull ghcr.io/iamvikshan/devcontainer/agents:latest
+docker pull ghcr.io/iamvikshan/devcontainer/ubuntu-tools:latest
 ```
 
 > **Alternative Sources:** All images are also available on
@@ -62,7 +62,7 @@ Add your chosen image to `.devcontainer/devcontainer.json`:
 ```json
 {
   "name": "My Bun Project",
-  "image": "ghcr.io/iamvikshan/devcontainers/bun:latest",
+  "image": "ghcr.io/iamvikshan/devcontainer/bun:latest",
   "customizations": {
     "vscode": {
       "extensions": ["oven.bun-vscode", "esbenp.prettier-vscode"],
@@ -82,14 +82,14 @@ Add your chosen image to `.devcontainer/devcontainer.json`:
 docker run -it --rm \
   -v $(pwd):/workspace \
   -w /workspace \
-  ghcr.io/iamvikshan/devcontainers/bun:latest \
+  ghcr.io/iamvikshan/devcontainer/bun:latest \
   zsh
 
 # Run commands directly
 docker run --rm \
   -v $(pwd):/workspace \
   -w /workspace \
-  ghcr.io/iamvikshan/devcontainers/bun:latest \
+  ghcr.io/iamvikshan/devcontainer/bun:latest \
   bun install
 ```
 
@@ -99,7 +99,7 @@ docker run --rm \
 version: '3.8'
 services:
   dev:
-    image: ghcr.io/iamvikshan/devcontainers/bun:latest
+    image: ghcr.io/iamvikshan/devcontainer/bun:latest
     volumes:
       - .:/workspace
     working_dir: /workspace

--- a/docs/IMAGE_VARIANTS.md
+++ b/docs/IMAGE_VARIANTS.md
@@ -5,12 +5,12 @@ images.
 
 ## 📊 Images Comparison
 
-| Feature         | bun               | bun-node               | ubuntu-bun       | ubuntu-bun-node   | ai                | ubuntu-tools          |
+| Feature         | bun               | bun-node               | ubuntu-bun       | ubuntu-bun-node   | agents            | ubuntu-tools          |
 | --------------- | ----------------- | ---------------------- | ---------------- | ----------------- | ----------------- | --------------------- |
 | **Base Image**  | oven/bun (Alpine) | oven/bun (Alpine)      | ubuntu:latest    | ubuntu:latest     | ubuntu:latest     | ubuntu:latest         |
-| **Size**        | ~57 MB | ~82 MB | ~117 MB | ~173 MB | ~200 MB | ~82 MB |
-| **Bun Version** | 1.3.14 | 1.3.14 | 1.3.14 | 1.3.14 | 1.3.14 | ❌ |
-| **Node.js**     | ❌ | ✅ v22.11.0 | ❌ | ✅ v24.18.0 | ❌ (Bun proxy) | ❌ |
+| **Size**        | ~57 MB            | ~82 MB                 | ~117 MB          | ~173 MB           | ~200 MB           | ~82 MB                |
+| **Bun Version** | 1.3.14            | 1.3.14                 | 1.3.14           | 1.3.14            | 1.3.14            | ❌                    |
+| **Node.js**     | ❌                | ✅ v22.11.0            | ❌               | ✅ v24.18.0       | ❌ (Bun proxy)    | ❌                    |
 | **npm**         | ❌                | ✅ 10.9.0              | ❌               | ✅ 10.9.0         | ❌                | ❌                    |
 | **Package Mgr** | Alpine (apk)      | Alpine (apk)           | Ubuntu (apt)     | Ubuntu (apt)      | Ubuntu (apt)      | Ubuntu (apt)          |
 | **Best For**    | Pure Bun projects | Full-stack development | Ubuntu workflows | Ubuntu full-stack | AI & custom tools | Tools-only automation |
@@ -30,7 +30,7 @@ images.
 
 ### 1. bun (~57 MB)
 
-**Primary Image:** `ghcr.io/iamvikshan/devcontainers/bun:latest`
+**Primary Image:** `ghcr.io/iamvikshan/devcontainer/bun:latest`
 
 **Description:** Lightweight Bun development environment based on the official
 Alpine-based Bun image. Perfect for pure Bun projects that don't require Node.js
@@ -64,7 +64,7 @@ compatibility.
 ```json
 {
   "name": "Pure Bun Project",
-  "image": "ghcr.io/iamvikshan/devcontainers/bun:latest",
+  "image": "ghcr.io/iamvikshan/devcontainer/bun:latest",
   "customizations": {
     "vscode": {
       "extensions": ["oven.bun-vscode", "oxc.oxc-vscode"]
@@ -76,7 +76,7 @@ compatibility.
 
 ### 2. bun-node (~82 MB)
 
-**Primary Image:** `ghcr.io/iamvikshan/devcontainers/bun-node:latest`
+**Primary Image:** `ghcr.io/iamvikshan/devcontainer/bun-node:latest`
 
 **Description:** Full-featured development environment with both Bun and
 Node.js. Ideal for projects that need Bun's performance with Node.js ecosystem
@@ -110,7 +110,7 @@ compatibility.
 ```json
 {
   "name": "Full-Stack Project",
-  "image": "ghcr.io/iamvikshan/devcontainers/bun-node:latest",
+  "image": "ghcr.io/iamvikshan/devcontainer/bun-node:latest",
   "customizations": {
     "vscode": {
       "extensions": ["oven.bun-vscode", "oxc.oxc-vscode"]
@@ -122,7 +122,7 @@ compatibility.
 
 ### 3. ubuntu-bun (~117 MB)
 
-**Primary Image:** `ghcr.io/iamvikshan/devcontainers/ubuntu-bun:latest`
+**Primary Image:** `ghcr.io/iamvikshan/devcontainer/ubuntu-bun:latest`
 
 **Description:** Ubuntu-based Bun environment for developers who prefer Ubuntu's
 package ecosystem and tooling. The smallest image in our collection!
@@ -156,7 +156,7 @@ package ecosystem and tooling. The smallest image in our collection!
 ```json
 {
   "name": "Ubuntu Bun Project",
-  "image": "ghcr.io/iamvikshan/devcontainers/ubuntu-bun:latest",
+  "image": "ghcr.io/iamvikshan/devcontainer/ubuntu-bun:latest",
   "customizations": {
     "vscode": {
       "extensions": ["oven.bun-vscode", "oxc.oxc-vscode"]
@@ -168,7 +168,7 @@ package ecosystem and tooling. The smallest image in our collection!
 
 ### 4. ubuntu-bun-node (~173 MB)
 
-**Primary Image:** `ghcr.io/iamvikshan/devcontainers/ubuntu-bun-node:latest`
+**Primary Image:** `ghcr.io/iamvikshan/devcontainer/ubuntu-bun-node:latest`
 
 **Description:** Complete Ubuntu-based development environment with Bun,
 Node.js, and npm. Best of both worlds with Ubuntu's flexibility and modern
@@ -204,7 +204,7 @@ JavaScript runtimes.
 ```json
 {
   "name": "Ubuntu Full-Stack Project",
-  "image": "ghcr.io/iamvikshan/devcontainers/ubuntu-bun-node:latest",
+  "image": "ghcr.io/iamvikshan/devcontainer/ubuntu-bun-node:latest",
   "customizations": {
     "vscode": {
       "extensions": ["oven.bun-vscode", "oxc.oxc-vscode"]
@@ -214,9 +214,9 @@ JavaScript runtimes.
 }
 ```
 
-### 5. ai (~160 MB)
+### 5. agents (~160 MB)
 
-**Primary Image:** `ghcr.io/iamvikshan/devcontainers/ai:latest`
+**Primary Image:** `ghcr.io/iamvikshan/devcontainer/agents:latest`
 
 **Description:** Ubuntu-based Bun environment configured for personal AI development, complete with coderabbit CLI and antigravity CLI (agy). It also routes Node.js command execution to Bun.
 
@@ -248,7 +248,7 @@ JavaScript runtimes.
 ```json
 {
   "name": "AI Bun Workspace",
-  "image": "ghcr.io/iamvikshan/devcontainers/ai:latest",
+  "image": "ghcr.io/iamvikshan/devcontainer/agents:latest",
   "customizations": {
     "vscode": {
       "extensions": ["oven.bun-vscode", "oxc.oxc-vscode", "coderabbit.coderabbit-vscode"]
@@ -259,7 +259,7 @@ JavaScript runtimes.
 
 ### 6. ubuntu-tools (~82 MB)
 
-**Primary Image:** `ghcr.io/iamvikshan/devcontainers/ubuntu-tools:latest`
+**Primary Image:** `ghcr.io/iamvikshan/devcontainer/ubuntu-tools:latest`
 
 **Description:** Ubuntu-based tools-only environment for automation, scripting,
 and utility-heavy workflows that do not require Bun or Node.js runtimes.
@@ -290,7 +290,7 @@ and utility-heavy workflows that do not require Bun or Node.js runtimes.
 ```json
 {
   "name": "Tools Workspace",
-  "image": "ghcr.io/iamvikshan/devcontainers/ubuntu-tools:latest",
+  "image": "ghcr.io/iamvikshan/devcontainer/ubuntu-tools:latest",
   "customizations": {
     "vscode": {
       "extensions": ["oxc.oxc-vscode"]
@@ -344,13 +344,13 @@ images are available from multiple registries:
 ### GitHub Container Registry (Primary)
 
 ```bash
-ghcr.io/iamvikshan/devcontainers/[image]:latest
+ghcr.io/iamvikshan/devcontainer/[image]:latest
 ```
 
 ### GitLab Container Registry
 
 ```bash
-registry.gitlab.com/vikshan/devcontainers/[image]:latest
+registry.gitlab.com/vikshan/devcontainers/devcontainer/[image]:latest
 ```
 
 ### Docker Hub

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -14,7 +14,7 @@ setup, so the examples below use `zsh`.
 | **bun-node**        | oven/bun | Bun, Node.js, npm, Git    | ~82 MB  | Full-stack with Bun + Node.js |
 | **ubuntu-bun**      | Ubuntu   | Bun, Git                  | ~160 MB | Ubuntu-based Bun development  |
 | **ubuntu-bun-node** | Ubuntu   | Bun, Node.js, npm, Git    | ~217 MB | Ubuntu-based full-stack       |
-| **ai**              | Ubuntu   | Bun, agy, CodeRabbit, Git | ~160 MB | Personal AI workspace         |
+| **agents**          | Ubuntu   | Bun, agy, CodeRabbit, Git | ~160 MB | Personal AI workspace         |
 | **ubuntu-tools**    | Ubuntu   | Python, jq, Git, curl     | ~127 MB | Tools-only automation         |
 
 ### 2. Registry Options
@@ -23,10 +23,10 @@ Choose your preferred registry:
 
 ```bash
 # GitHub Container Registry (Recommended)
-ghcr.io/iamvikshan/devcontainers/[image]:latest
+ghcr.io/iamvikshan/devcontainer/[image]:latest
 
 # GitLab Container Registry
-registry.gitlab.com/vikshan/devcontainers/[image]:latest
+registry.gitlab.com/vikshan/devcontainers/devcontainer/[image]:latest
 
 # Docker Hub
 docker.io/vikshan/[image]:latest
@@ -45,7 +45,7 @@ docker.io/vikshan/[image]:latest
    ```json
    {
      "name": "My Project",
-     "image": "ghcr.io/iamvikshan/devcontainers/bun:latest",
+     "image": "ghcr.io/iamvikshan/devcontainer/bun:latest",
      "customizations": {
        "vscode": {
          "extensions": ["oven.bun-vscode", "esbenp.prettier-vscode", "dbaeumer.vscode-eslint"],
@@ -69,14 +69,14 @@ docker.io/vikshan/[image]:latest
 docker run -it --rm \
   -v $(pwd):/workspace \
   -w /workspace \
-  ghcr.io/iamvikshan/devcontainers/bun:latest \
+  ghcr.io/iamvikshan/devcontainer/bun:latest \
   zsh
 
 # Run specific commands
 docker run --rm \
   -v $(pwd):/workspace \
   -w /workspace \
-  ghcr.io/iamvikshan/devcontainers/bun:latest \
+  ghcr.io/iamvikshan/devcontainer/bun:latest \
   bun install
 ```
 
@@ -86,7 +86,7 @@ docker run --rm \
 version: '3.8'
 services:
   dev:
-    image: ghcr.io/iamvikshan/devcontainers/bun:latest
+    image: ghcr.io/iamvikshan/devcontainer/bun:latest
     volumes:
       - .:/workspace
     working_dir: /workspace

--- a/images/agents/Dockerfile
+++ b/images/agents/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 
-# renovate: datasource=docker depName=ghcr.io/iamvikshan/devcontainers/bun-node-node
+# renovate: datasource=docker depName=ghcr.io/iamvikshan/devcontainer/ubuntu-bun-node
 ARG BASE_TAG="latest"
-FROM ghcr.io/iamvikshan/devcontainers/bun-node-node:${BASE_TAG}
+FROM ghcr.io/iamvikshan/devcontainer/ubuntu-bun-node:${BASE_TAG}
 
 ARG BASE_TAG
 ARG USERNAME=root
@@ -35,7 +35,7 @@ USER ${USERNAME}
 
 # Inject Metadata for Skopeo Extraction
 LABEL org.opencontainers.image.title="ai-harness" \
-      org.opencontainers.image.base.name="ghcr.io/iamvikshan/devcontainers/ubuntu-bun-node:${BASE_TAG}" \
+      org.opencontainers.image.base.name="ghcr.io/iamvikshan/devcontainer/ubuntu-bun-node:${BASE_TAG}" \
       devcontainer.tool.coderabbit="latest" \
       devcontainer.tool.agy="latest" \
       devcontainer.tool.opencode="latest" \

--- a/images/agents/Dockerfile
+++ b/images/agents/Dockerfile
@@ -34,7 +34,7 @@ RUN npm install -g openwiki omniroute \
 USER ${USERNAME}
 
 # Inject Metadata for Skopeo Extraction
-LABEL org.opencontainers.image.title="ai-harness" \
+LABEL org.opencontainers.image.title="ai-agents" \
       org.opencontainers.image.base.name="ghcr.io/iamvikshan/devcontainer/ubuntu-bun-node:${BASE_TAG}" \
       devcontainer.tool.coderabbit="latest" \
       devcontainer.tool.agy="latest" \

--- a/images/bun-node/Dockerfile
+++ b/images/bun-node/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 
 # 1. Base Image Tracking
-# renovate: datasource=docker depName=ghcr.io/iamvikshan/devcontainers/bun
+# renovate: datasource=docker depName=ghcr.io/iamvikshan/devcontainer/bun
 ARG BASE_TAG="latest"
 
-FROM ghcr.io/iamvikshan/devcontainers/bun:${BASE_TAG}
+FROM ghcr.io/iamvikshan/devcontainer/bun:${BASE_TAG}
 
 ARG BASE_TAG
 
@@ -23,7 +23,7 @@ USER ${USERNAME}
 
 # 5. Inject Metadata for Skopeo Extraction
 LABEL org.opencontainers.image.title="bun-node" \
-      org.opencontainers.image.base.name="ghcr.io/iamvikshan/devcontainers/bun:${BASE_TAG}" \
+      org.opencontainers.image.base.name="ghcr.io/iamvikshan/devcontainer/bun:${BASE_TAG}" \
       devcontainer.tool.bun="${BUN_VERSION}"
 
 CMD ["sleep", "infinity"]

--- a/images/ubuntu-bun-node/Dockerfile
+++ b/images/ubuntu-bun-node/Dockerfile
@@ -2,14 +2,14 @@
 
 # renovate: datasource=docker depName=oven/bun
 ARG BUN_VERSION="1.3.14"
-# renovate: datasource=docker depName=ghcr.io/iamvikshan/devcontainers/ubuntu-tools
+# renovate: datasource=docker depName=ghcr.io/iamvikshan/devcontainer/ubuntu-tools
 ARG BASE_TAG="latest"
 
 # 1. Define Bun Source for Multi-Stage Copy (using glibc-compatible slim image)
 FROM oven/bun:${BUN_VERSION}-slim AS bun_source
 
 # 2. Base Image Tracking
-FROM ghcr.io/iamvikshan/devcontainers/ubuntu-tools:${BASE_TAG}
+FROM ghcr.io/iamvikshan/devcontainer/ubuntu-tools:${BASE_TAG}
 
 # 3. Re-declare ARGs for Renovate tracking and Label injection
 ARG BUN_VERSION
@@ -42,7 +42,7 @@ USER ${USERNAME}
 
 # 6. Inject Metadata for Skopeo Extraction
 LABEL org.opencontainers.image.title="ubuntu-bun-node" \
-      org.opencontainers.image.base.name="ghcr.io/iamvikshan/devcontainers/ubuntu-tools:${BASE_TAG}" \
+      org.opencontainers.image.base.name="ghcr.io/iamvikshan/devcontainer/ubuntu-tools:${BASE_TAG}" \
       devcontainer.tool.bun="${BUN_VERSION}" \
       devcontainer.tool.node="${NODE_VERSION}"
 

--- a/images/ubuntu-bun/Dockerfile
+++ b/images/ubuntu-bun/Dockerfile
@@ -2,14 +2,14 @@
 
 # renovate: datasource=docker depName=oven/bun
 ARG BUN_VERSION="1.3.14"
-# renovate: datasource=docker depName=ghcr.io/iamvikshan/devcontainers/ubuntu-tools
+# renovate: datasource=docker depName=ghcr.io/iamvikshan/devcontainer/ubuntu-tools
 ARG BASE_TAG="latest"
 
 # 1. Define Bun Source for Multi-Stage Copy (using glibc-compatible slim image)
 FROM oven/bun:${BUN_VERSION}-slim AS bun_source
 
 # 2. Base Image Tracking
-FROM ghcr.io/iamvikshan/devcontainers/ubuntu-tools:${BASE_TAG}
+FROM ghcr.io/iamvikshan/devcontainer/ubuntu-tools:${BASE_TAG}
 
 # 3. Re-declare ARGs for Renovate tracking and Label injection
 ARG BUN_VERSION
@@ -28,7 +28,7 @@ USER ${USERNAME}
 
 # 6. Inject Metadata for Skopeo Extraction
 LABEL org.opencontainers.image.title="ubuntu-bun" \
-      org.opencontainers.image.base.name="ghcr.io/iamvikshan/devcontainers/ubuntu-tools:${BASE_TAG}" \
+      org.opencontainers.image.base.name="ghcr.io/iamvikshan/devcontainer/ubuntu-tools:${BASE_TAG}" \
       devcontainer.tool.bun="${BUN_VERSION}"
 
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
This PR aligns devcontainer registry names to match the rename to devcontainer (singular) and corrects badge/repo links.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns all images to the `ghcr.io/iamvikshan/devcontainer` namespace and renames the `ai` image to `agents`. Fixes badges/links in docs and workflows; updates README, quick-starts, and `.devcontainer` examples.

- **Refactors**
  - Standardized GHCR and GitLab paths to `ghcr.io/iamvikshan/devcontainer/*` and `registry.gitlab.com/vikshan/devcontainers/devcontainer/*`.
  - Renamed `ai` → `agents` across code and docs, including workflow jobs/artifacts/matrices, Skopeo metadata files, labels, and `.devcontainer/devcontainer.json`.
  - Updated release workflow: `GHCR_BASE` to `devcontainer`, publish to new GitLab path, renamed `build-ai` → `build-agents`, adjusted finalize/cleanup matrices, and pruned `devcontainer/*` images.
  - Switched `agents` base to `ubuntu-bun-node`; refreshed Dockerfile labels and `renovate` dep names.
  - Fixed release notes link generation to use `$OWNER/devcontainer` for GHCR.

- **Migration**
  - Replace `ghcr.io/iamvikshan/devcontainers/*` with `ghcr.io/iamvikshan/devcontainer/*` in configs and scripts.
  - If using `ai`, switch to `agents` (e.g., `ghcr.io/iamvikshan/devcontainer/agents:latest`).
  - GitLab users: use `registry.gitlab.com/vikshan/devcontainers/devcontainer/*`.

<sup>Written for commit ae3b854d6cd572e1912409ce232167a50b6e7cd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/iamvikshan/devcontainers/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

